### PR TITLE
Hacer que los space marines ahorren 5 turnos y pierdan 3 menos de ene…

### DIFF
--- a/Data/World/Buildings/SpaceMarines/Construction.xml
+++ b/Data/World/Buildings/SpaceMarines/Construction.xml
@@ -3,17 +3,18 @@
 	<modifiers>
 		<modifier visible="0">
 			<effects>
-				<productionCost base="48"/>
+				<productionCost base="42"/>
 				<requisitionsCost base="80"/>
 				<populationRequired base="1"/>
 				<slotsRequired base="1"/>
-				<energyUpkeep add="3"/>
+				<energyUpkeep add="1"/>
 			</effects>
 		</modifier>
 		<modifier>
 			<effects>
 				<influence add="6"/>
 				<production add="6"/>
+				<populationLimit add="2"/>
 			</effects>
 		</modifier>
 	</modifiers>

--- a/Data/World/Buildings/SpaceMarines/Headquarters.xml
+++ b/Data/World/Buildings/SpaceMarines/Headquarters.xml
@@ -11,10 +11,10 @@
 		<modifier>
 			<effects>
 				<cityRadius add="1"/>
-				<energy add="6"/>
+				<energy add="4"/>
 				<loyalty add="6"/>
 				<influence add="6"/>
-				<populationLimit add="6"/>
+				<populationLimit add="4"/>
 				<requisitions add="12"/>
 				<research add="6"/>
 			</effects>

--- a/Data/World/Buildings/SpaceMarines/Housing.xml
+++ b/Data/World/Buildings/SpaceMarines/Housing.xml
@@ -3,11 +3,11 @@
 	<modifiers>
 		<modifier visible="0">
 			<effects>
-				<productionCost base="36"/>
-				<requisitionsCost base="50"/>
+				<productionCost base="12"/>
+				<requisitionsCost base="20"/>
 				<populationRequired base="0"/>
 				<slotsRequired base="1"/>
-				<energyUpkeep add="2"/>
+				<energyUpkeep add="1"/>
 			</effects>
 		</modifier>
 		<modifier>


### PR DESCRIPTION
…rgía (2 por constructor y uno por housing) cuando construyen un constructor y un housing.

Headquarter:
populationLimit: de +6 bajar a +4
energy: de +6 bajar a +4

Construction:
productionCost: de 48 bajar a 42 (un turno menos)
populationLimit: de +0 subir a +2
energyUpkeep: de 3 bajar a 1

Housing:
productionCost: de 36 bajar a 12 (4 turnos menos)
requisitionsCost: de 50 bajar a 20
energyUpkeep: de 2 bajar a 1